### PR TITLE
Update the ldap depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -128,7 +128,7 @@ Description: transitional dummy package
 
 Package: php5-ldap
 Architecture: all
-Depends: php5.6-imap,
+Depends: php5.6-ldap,
          ${misc:Depends}
 Description: transitional dummy package
  This is a transitional dummy package. It can safely be removed.


### PR DESCRIPTION
Since I have no idea how PPAs work, I don't  know if I should be compiling something, but I found a typo in the depends for the compatibility on ldap.
